### PR TITLE
Refactor varint handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,6 @@ dependencies = [
  "snafu",
  "snap",
  "tokio",
- "zigzag",
  "zstd",
 ]
 
@@ -1532,15 +1531,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "zigzag"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,4 @@ tokio = { version = "1.28", features = [
     "macros",
     "rt",
 ] }
-zigzag = "0.1"
 zstd = "0.12"

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,8 +76,8 @@ pub enum Error {
         source: ArrowError,
     },
 
-    #[snafu(display("Unsigned VInt"))]
-    EofUnsignedVInt { location: Location },
+    #[snafu(display("Varint being decoded is too large"))]
+    VarintTooLarge { location: Location },
 
     #[snafu(display("unexpected: {}", msg))]
     Unexpected { location: Location, msg: String },

--- a/src/reader/decode/rle_v2/delta.rs
+++ b/src/reader/decode/rle_v2/delta.rs
@@ -5,14 +5,14 @@ use snafu::ensure;
 use crate::error::{self, Result};
 use crate::reader::decode::rle_v2::RleReaderV2;
 use crate::reader::decode::util::{
-    read_ints, read_u8, read_vslong, read_vulong, rle_v2_delta_bit_width,
+    read_ints, read_u8, read_vslong, read_vulong, rle_v2_direct_bit_width,
 };
 
 impl<R: Read> RleReaderV2<R> {
     pub fn read_delta_values(&mut self, header: u8) -> Result<()> {
         let mut fb = (header >> 1) & 0x1f;
         if fb != 0 {
-            fb = rle_v2_delta_bit_width(fb);
+            fb = rle_v2_direct_bit_width(fb);
         }
         let reader = &mut self.reader;
         let signed = self.signed;
@@ -26,7 +26,7 @@ impl<R: Read> RleReaderV2<R> {
         let first_val = if signed {
             read_vslong(reader)?
         } else {
-            read_vulong(reader)?
+            read_vulong(reader)? as i64
         };
 
         self.literals[self.num_literals] = first_val;

--- a/src/reader/decode/rle_v2/direct.rs
+++ b/src/reader/decode/rle_v2/direct.rs
@@ -2,12 +2,12 @@ use std::io::Read;
 
 use crate::error::Result;
 use crate::reader::decode::rle_v2::RleReaderV2;
-use crate::reader::decode::util::{read_ints, read_u8, rle_v2_delta_bit_width, zigzag_decode};
+use crate::reader::decode::util::{read_ints, read_u8, rle_v2_direct_bit_width, zigzag_decode};
 
 impl<R: Read> RleReaderV2<R> {
     pub fn read_direct_values(&mut self, header: u8) -> Result<()> {
         let fbo = (header >> 1) & 0x1F;
-        let fb = rle_v2_delta_bit_width(fbo);
+        let fb = rle_v2_direct_bit_width(fbo);
 
         // 9 bits for length (L) (1 to 512 values)
         let second_byte = read_u8(&mut self.reader)?;


### PR DESCRIPTION
Remove zigzag dependency (no need to pull in extra dependency for this)

Remove usage of `rle_v2_delta_bit_width()` which is duplicated with `rle_v2_direct_bit_width()`

Refactor `read_vulong()`