### PR TITLE
fix: read entire file with ArrowReader

### DIFF
--- a/tests/basic/main.rs
+++ b/tests/basic/main.rs
@@ -275,6 +275,15 @@ pub fn v0_file_test() {
     assert_eq!(expected_row_count as usize, total_rows);
 }
 
+#[tokio::test]
+pub async fn v0_file_test_async() {
+    let path = basic_path("demo-11-zlib.orc");
+    let reader = new_arrow_stream_reader_root(&path).await;
+    let batches = reader.try_collect::<Vec<_>>().await.unwrap();
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(1_920_800, total_rows);
+}
+
 #[test]
 pub fn alltypes_test() {
     let compressions = ["none", "snappy", "zlib", "lzo", "zstd", "lz4"];

--- a/tests/basic/main.rs
+++ b/tests/basic/main.rs
@@ -269,11 +269,10 @@ pub async fn async_basic_test_0() {
 pub fn v0_file_test() {
     let path = basic_path("demo-11-zlib.orc");
     let reader = new_arrow_reader_root(&path);
-    let _expected_row_count = reader.total_row_count();
+    let expected_row_count = reader.total_row_count();
     let batches = reader.collect::<Result<Vec<_>, _>>().unwrap();
-    let _total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-    // TODO: not reading entire file, debug
-    // assert_eq!(expected_row_count as usize, total_rows);
+    let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+    assert_eq!(expected_row_count as usize, total_rows);
 }
 
 #[test]


### PR DESCRIPTION
Previously wasn't able to read past first stripe in ArrowReader, fix to allow