### PR TITLE
refactor: refactor byte/boolean iter

### DIFF
--- a/src/arrow_reader/column/boolean.rs
+++ b/src/arrow_reader/column/boolean.rs
@@ -9,14 +9,12 @@ use crate::reader::decode::boolean_rle::BooleanIter;
 
 pub fn new_boolean_iter(column: &Column, stripe: &Stripe) -> Result<NullableIterator<bool>> {
     let present = new_present_iter(column, stripe)?.collect::<Result<Vec<_>>>()?;
-    let rows: usize = present.iter().filter(|&p| *p).count();
 
     let iter = stripe
         .stream_map
         .get(column, Kind::Data)
         .map(|reader| {
-            Box::new(BooleanIter::new(reader, rows))
-                as Box<dyn Iterator<Item = Result<bool>> + Send>
+            Box::new(BooleanIter::new(reader)) as Box<dyn Iterator<Item = Result<bool>> + Send>
         })
         .context(InvalidColumnSnafu { name: &column.name })?;
 

--- a/src/arrow_reader/column/present.rs
+++ b/src/arrow_reader/column/present.rs
@@ -12,9 +12,7 @@ pub fn new_present_iter(
     let iter = stripe
         .stream_map
         .get(column, Kind::Present)
-        .map(|reader| {
-            Box::new(BooleanIter::new(reader, rows)) as Box<dyn Iterator<Item = Result<bool>>>
-        })
+        .map(|reader| Box::new(BooleanIter::new(reader)) as Box<dyn Iterator<Item = Result<bool>>>)
         .unwrap_or_else(|| Box::new(DummyPresentIter::new(rows)));
 
     Ok(iter)

--- a/src/arrow_reader/column/tinyint.rs
+++ b/src/arrow_reader/column/tinyint.rs
@@ -9,14 +9,12 @@ use crate::reader::decode::byte_rle::ByteRleIter;
 
 pub fn new_i8_iter(column: &Column, stripe: &Stripe) -> Result<NullableIterator<i8>> {
     let present = new_present_iter(column, stripe)?.collect::<Result<Vec<_>>>()?;
-    let rows: usize = present.iter().filter(|&p| *p).count();
 
     let iter = stripe
         .stream_map
         .get(column, Kind::Data)
         .map(|reader| {
-            Box::new(ByteRleIter::new(reader, rows).map(|value| value.map(|value| value as i8)))
-                as _
+            Box::new(ByteRleIter::new(reader).map(|value| value.map(|value| value as i8))) as _
         })
         .context(InvalidColumnSnafu { name: &column.name })?;
 


### PR DESCRIPTION
I'm trying to implement the list datatype. However, I found that our present iterator relies on the `number_of_rows` of stripe, which made the nested lists also rely on it.