### PR TITLE
Refactor to decouple from relying directly on proto

### DIFF
--- a/src/arrow_reader/column.rs
+++ b/src/arrow_reader/column.rs
@@ -115,10 +115,10 @@ impl Column {
         name: &str,
         column: &Arc<TypeDescription>,
         footer: &Arc<StripeFooter>,
-        stripe: &StripeInformation,
+        number_of_rows: u64,
     ) -> Self {
         Self {
-            number_of_rows: stripe.number_of_rows(),
+            number_of_rows,
             footer: footer.clone(),
             column: column.clone(),
             name: name.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub(crate) mod builder;
 pub mod error;
 pub mod proto;
 pub mod reader;
+pub mod statistics;
+pub mod stripe;
 
 pub use arrow_reader::{ArrowReader, Cursor};
 pub use async_arrow_reader::ArrowStreamReader;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,49 +5,25 @@ pub mod schema;
 
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
-use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncSeek};
 
 use self::metadata::{read_metadata, FileMetadata};
-use self::schema::{create_schema, TypeDescription};
-use crate::arrow_reader::Cursor;
+use self::schema::TypeDescription;
 use crate::error::Result;
-use crate::proto::{StripeFooter, StripeInformation};
+use crate::proto::StripeFooter;
 use crate::reader::metadata::read_metadata_async;
+use crate::stripe::StripeMetadata;
 
 pub struct Reader<R> {
     pub(crate) inner: R,
     metadata: Box<FileMetadata>,
-    pub(crate) schema: Arc<TypeDescription>,
 }
 
 impl<R: ChunkReader> Reader<R> {
     pub fn new(mut r: R) -> Result<Self> {
         let metadata = Box::new(read_metadata(&mut r)?);
-        let schema = create_schema(&metadata.footer.types, 0)?;
-
-        Ok(Self {
-            inner: r,
-            metadata,
-            schema,
-        })
-    }
-}
-
-impl<R: Read> Reader<R> {
-    pub fn new_with_metadata(r: R, metadata: FileMetadata) -> Result<Self> {
-        let schema = create_schema(&metadata.footer.types, 0)?;
-
-        Ok(Self {
-            inner: r,
-            metadata: Box::new(metadata),
-            schema,
-        })
-    }
-
-    pub fn select(self, fields: &[&str]) -> Result<Cursor<R>> {
-        Cursor::new(self, fields)
+        Ok(Self { inner: r, metadata })
     }
 }
 
@@ -57,28 +33,22 @@ impl<R> Reader<R> {
     }
 
     pub fn schema(&self) -> &TypeDescription {
-        &self.schema
+        self.metadata.type_description()
     }
 
-    pub fn stripe(&self, index: usize) -> Option<StripeInformation> {
-        self.metadata.footer.stripes.get(index).cloned()
+    pub fn stripe(&self, index: usize) -> Option<&StripeMetadata> {
+        self.metadata.stripe_metadatas().get(index)
     }
 
     pub fn stripe_footer(&mut self, stripe: usize) -> &StripeFooter {
-        &self.metadata.stripe_footers[stripe]
+        &self.metadata.stripe_footers()[stripe]
     }
 }
 
 impl<R: AsyncRead + AsyncSeek + Unpin + Send> Reader<R> {
     pub async fn new_async(mut r: R) -> Result<Self> {
         let metadata = Box::new(read_metadata_async(&mut r).await?);
-        let schema = create_schema(&metadata.footer.types, 0)?;
-
-        Ok(Self {
-            inner: r,
-            metadata,
-            schema,
-        })
+        Ok(Self { inner: r, metadata })
     }
 }
 

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -24,10 +24,6 @@ impl ColumnStatistics {
     }
 }
 
-// TODO: Currently mapping exactly to proto.
-//       But we can replace with our own specific types
-//       if makes things easier (e.g. use a Decimal type
-//       instead of just string)
 #[derive(Debug, Clone)]
 pub enum TypeStatistics {
     /// For TinyInt, SmallInt, Int and BigInt

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,0 +1,150 @@
+use crate::{error, proto};
+
+/// Contains statistics for a specific column, for the entire file
+/// or for a specific stripe.
+#[derive(Debug, Clone)]
+pub struct ColumnStatistics {
+    number_of_values: u64,
+    /// Use aid in 'IS NULL' predicates
+    has_null: bool,
+    type_statistics: Option<TypeStatistics>,
+}
+
+impl ColumnStatistics {
+    pub fn number_of_values(&self) -> u64 {
+        self.number_of_values
+    }
+
+    pub fn has_null(&self) -> bool {
+        self.has_null
+    }
+
+    pub fn type_statistics(&self) -> Option<&TypeStatistics> {
+        self.type_statistics.as_ref()
+    }
+}
+
+// TODO: Currently mapping exactly to proto.
+//       But we can replace with our own specific types
+//       if makes things easier (e.g. use a Decimal type
+//       instead of just string)
+#[derive(Debug, Clone)]
+pub enum TypeStatistics {
+    /// For TinyInt, SmallInt, Int and BigInt
+    Integer {
+        min: i64,
+        max: i64,
+        /// If sum overflows then recorded as None
+        sum: Option<i64>,
+    },
+    /// For Float and Double
+    Double {
+        min: f64,
+        max: f64,
+        /// If sum overflows then recorded as None
+        sum: Option<f64>,
+    },
+    String {
+        min: String,
+        max: String,
+        /// Total length of all strings
+        sum: i64,
+    },
+    /// For Boolean
+    Bucket { true_count: u64 },
+    Decimal {
+        // TODO: use our own decimal type?
+        min: String,
+        max: String,
+        sum: String,
+    },
+    Date {
+        /// Days since epoch
+        min: i32,
+        max: i32,
+    },
+    Binary {
+        // Total number of bytes across all values
+        sum: i64,
+    },
+    Timestamp {
+        /// Milliseconds since epoch
+        /// These were used before ORC-135
+        /// Where local timezone offset was included
+        min: i64,
+        max: i64,
+        /// Milliseconds since UNIX epoch
+        min_utc: i64,
+        max_utc: i64,
+    },
+    Collection {
+        min_children: u64,
+        max_children: u64,
+        total_children: u64,
+    },
+}
+
+impl TryFrom<&proto::ColumnStatistics> for ColumnStatistics {
+    type Error = error::Error;
+
+    fn try_from(value: &proto::ColumnStatistics) -> Result<Self, Self::Error> {
+        let type_statistics = if let Some(stats) = &value.int_statistics {
+            Some(TypeStatistics::Integer {
+                min: stats.minimum(),
+                max: stats.maximum(),
+                sum: stats.sum,
+            })
+        } else if let Some(stats) = &value.double_statistics {
+            Some(TypeStatistics::Double {
+                min: stats.minimum(),
+                max: stats.maximum(),
+                sum: stats.sum,
+            })
+        } else if let Some(stats) = &value.string_statistics {
+            Some(TypeStatistics::String {
+                min: stats.minimum().to_owned(),
+                max: stats.maximum().to_owned(),
+                sum: stats.sum(),
+            })
+        } else if let Some(stats) = &value.bucket_statistics {
+            // TODO: false count?
+            Some(TypeStatistics::Bucket {
+                true_count: stats.count[0], // TODO: safety check this
+            })
+        } else if let Some(stats) = &value.decimal_statistics {
+            Some(TypeStatistics::Decimal {
+                min: stats.minimum().to_owned(),
+                max: stats.maximum().to_owned(),
+                sum: stats.sum().to_owned(),
+            })
+        } else if let Some(stats) = &value.date_statistics {
+            Some(TypeStatistics::Date {
+                min: stats.minimum(),
+                max: stats.maximum(),
+            })
+        } else if let Some(stats) = &value.binary_statistics {
+            Some(TypeStatistics::Binary { sum: stats.sum() })
+        } else if let Some(stats) = &value.timestamp_statistics {
+            Some(TypeStatistics::Timestamp {
+                min: stats.minimum(),
+                max: stats.maximum(),
+                min_utc: stats.minimum_utc(),
+                max_utc: stats.maximum_utc(),
+            })
+        } else {
+            value
+                .collection_statistics
+                .as_ref()
+                .map(|stats| TypeStatistics::Collection {
+                    min_children: stats.min_children(),
+                    max_children: stats.max_children(),
+                    total_children: stats.total_children(),
+                })
+        };
+        Ok(Self {
+            number_of_values: value.number_of_values(),
+            has_null: value.has_null(),
+            type_statistics,
+        })
+    }
+}

--- a/src/stripe.rs
+++ b/src/stripe.rs
@@ -1,0 +1,69 @@
+use crate::{error, proto, statistics::ColumnStatistics};
+
+/// Stripe metadata parsed from the file tail metadata sections.
+/// Does not contain the actual stripe bytes, as those are decoded
+/// when they are required.
+#[derive(Debug, Clone)]
+pub struct StripeMetadata {
+    /// Statistics of columns across this specific stripe
+    column_statistics: Vec<ColumnStatistics>,
+    /// Byte offset of start of stripe from start of file
+    offset: u64,
+    /// Byte length of index section
+    index_length: u64,
+    /// Byte length of data section
+    data_length: u64,
+    /// Byte length of footer section
+    footer_length: u64,
+    /// Number of rows in the stripe
+    number_of_rows: u64,
+}
+
+impl StripeMetadata {
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    pub fn index_length(&self) -> u64 {
+        self.index_length
+    }
+
+    pub fn data_length(&self) -> u64 {
+        self.data_length
+    }
+
+    pub fn footer_length(&self) -> u64 {
+        self.footer_length
+    }
+
+    pub fn number_of_rows(&self) -> u64 {
+        self.number_of_rows
+    }
+
+    pub fn column_statistics(&self) -> &[ColumnStatistics] {
+        &self.column_statistics
+    }
+}
+
+impl TryFrom<(&proto::StripeInformation, &proto::StripeStatistics)> for StripeMetadata {
+    type Error = error::Error;
+
+    fn try_from(
+        value: (&proto::StripeInformation, &proto::StripeStatistics),
+    ) -> Result<Self, Self::Error> {
+        let column_statistics = value
+            .1
+            .col_stats
+            .iter()
+            .map(TryFrom::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            column_statistics,
+            offset: value.0.offset(),
+            index_length: value.0.index_length(),
+            data_length: value.0.data_length(),
+            footer_length: value.0.footer_length(),
+            number_of_rows: value.0.number_of_rows(),
+        })
+    }
+}


### PR DESCRIPTION
Part of https://github.com/datafusion-contrib/datafusion-orc/issues/41

Start introducing some of our own structs/types to represent their protobuf counter part

Allows us to have more control, such as ensuring fields are actually present (since proto has them as Option usually)