### PR TITLE
Add ArrowReaderBuilder

### DIFF
--- a/src/async_arrow_reader.rs
+++ b/src/async_arrow_reader.rs
@@ -14,8 +14,7 @@ use snafu::ResultExt;
 
 use crate::arrow_reader::column::Column;
 use crate::arrow_reader::{
-    create_arrow_schema, deserialize_stripe_footer, Cursor, NaiveStripeDecoder, StreamMap, Stripe,
-    DEFAULT_BATCH_SIZE,
+    deserialize_stripe_footer, Cursor, NaiveStripeDecoder, StreamMap, Stripe,
 };
 use crate::error::{IoSnafu, Result};
 use crate::reader::metadata::FileMetadata;
@@ -110,13 +109,11 @@ impl<R: AsyncChunkReader + 'static> StripeFactory<R> {
 }
 
 impl<R: AsyncChunkReader + 'static> ArrowStreamReader<R> {
-    pub fn new(c: Cursor<R>, batch_size: Option<usize>) -> Self {
-        let batch_size = batch_size.unwrap_or(DEFAULT_BATCH_SIZE);
-        let schema = Arc::new(create_arrow_schema(&c));
+    pub fn new(cursor: Cursor<R>, batch_size: usize, schema_ref: SchemaRef) -> Self {
         Self {
-            factory: Some(Box::new(c.into())),
+            factory: Some(Box::new(cursor.into())),
             batch_size,
-            schema_ref: schema,
+            schema_ref,
             state: StreamState::Init,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,5 @@ pub mod schema;
 pub mod statistics;
 pub mod stripe;
 
-pub use arrow_reader::{ArrowReader, Cursor};
+pub use arrow_reader::{ArrowReader, ArrowReaderBuilder};
 pub use async_arrow_reader::ArrowStreamReader;


### PR DESCRIPTION
Closes #42

Introduce a builder which can create the sync/async reader, without requiring users to create a Cursor first

Also can be used to handle option settings (like projection and batch size)