### PR TITLE
Switch CI toolchain to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 name: CI
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-05-03
+  RUST_TOOLCHAIN: stable
 
 jobs:
   typos:


### PR DESCRIPTION
Seeing CI failure: https://github.com/datafusion-contrib/datafusion-orc/actions/runs/7360911822/job/20037635643?pr=53

```
 error[E0658]: use of unstable library feature 'build_hasher_simple_hash_one'
   --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ahash-0.8.7/src/random_state.rs:463:5
    |
463 | /     fn hash_one<T: Hash>(&self, x: T) -> u64 {
464 | |         RandomState::hash_one(self, x)
465 | |     }
    | |_____^
    |
    = note: see issue #86161 <https://github.com/rust-lang/rust/issues/86161> for more information
    = help: add `#![feature(build_hasher_simple_hash_one)]` to the crate attributes to enable
```