### PR TITLE
Introduce generics into RLE Int decoders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = "0.3"
 lz4_flex = "0.11"
 lzokay-native = "0.1"
+num = "0.4.1"
 paste = "1.0"
 prost = { version = "0.11" }
 snafu = "0.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use crate::proto::r#type::Kind;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-pub enum Error {
+pub enum OrcError {
     #[snafu(display("Failed to seek, source: {}", source))]
     SeekError {
         source: std::io::Error,
@@ -124,10 +124,10 @@ pub enum Error {
     },
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, OrcError>;
 
-impl From<Error> for ArrowError {
-    fn from(value: Error) -> Self {
+impl From<OrcError> for ArrowError {
+    fn from(value: OrcError) -> Self {
         ArrowError::ExternalError(Box::new(value))
     }
 }

--- a/src/reader/decode/rle_v1.rs
+++ b/src/reader/decode/rle_v1.rs
@@ -19,206 +19,101 @@
 
 use std::io::Read;
 
-use crate::error::Result;
+use snafu::OptionExt;
 
-use super::util::{read_u8, read_vslong, read_vulong, try_read_u8};
+use crate::error::{OutOfSpecSnafu, Result};
 
-/// Hold state of the decoding effort.
-enum UnsignedDecodingState {
-    /// First created, haven't read anything
-    Initial,
-    /// Sequence of integers that differ by a fixed delta.
-    Run {
-        base: u64,
-        delta: i64,
-        length: usize,
-    },
-    /// Sequence of `length` varint encoded integers.
-    Literals { length: usize },
-    /// Exhausted input stream.
-    Exhausted,
-}
+use super::{
+    util::{read_u8, read_varint_zigzagged, try_read_u8},
+    NInt,
+};
 
-impl UnsignedDecodingState {
-    /// Decode header byte to determine sub-encoding.
-    /// Runs start with a positive byte, and literals with a negative byte.
-    fn get_state<R: Read>(reader: &mut R) -> Result<Self> {
-        match try_read_u8(reader)?.map(|byte| byte as i8) {
-            Some(byte) if byte < 0 => {
-                let length = byte.unsigned_abs() as usize;
-                Ok(Self::Literals { length })
-            }
-            Some(byte) => {
-                let byte = byte as u8;
-                let length = byte as usize + 3;
-                let delta = read_u8(reader)? as i8;
-                let delta = delta as i64;
-                let base = read_vulong(reader)?;
-                Ok(Self::Run {
-                    base,
-                    delta,
-                    length,
-                })
-            }
-            None => Ok(Self::Exhausted),
-        }
-    }
-}
+const MAX_RUN_LENGTH: usize = 130;
 
 /// Decodes a stream of Integer Run Length Encoded version 1 bytes.
-pub struct UnsignedRleReaderV1<R: Read> {
+pub struct RleReaderV1<N: NInt, R: Read> {
     reader: R,
-    state: UnsignedDecodingState,
+    decoded_ints: Vec<N>,
+    current_head: usize,
 }
 
-impl<R: Read> UnsignedRleReaderV1<R> {
+impl<N: NInt, R: Read> RleReaderV1<N, R> {
     pub fn new(reader: R) -> Self {
         Self {
             reader,
-            state: UnsignedDecodingState::Initial,
+            decoded_ints: Vec::with_capacity(MAX_RUN_LENGTH),
+            current_head: 0,
         }
     }
 
-    fn iter_helper(&mut self) -> Result<Option<u64>> {
-        match self.state {
-            UnsignedDecodingState::Initial => {
-                self.state = UnsignedDecodingState::get_state(&mut self.reader)?;
-                // this is safe as UnsignedDecodingState::Initial is only ever set in new()
-                self.iter_helper()
-            }
-            UnsignedDecodingState::Run {
-                base,
-                delta,
-                length,
-            } => {
-                let num = base;
-                if length == 1 {
-                    self.state = UnsignedDecodingState::get_state(&mut self.reader)?;
-                } else {
-                    self.state = UnsignedDecodingState::Run {
-                        base: base.saturating_add_signed(delta),
-                        delta,
-                        length: length - 1,
-                    };
-                }
-                Ok(Some(num))
-            }
-            UnsignedDecodingState::Literals { length } => {
-                let num = read_vulong(&mut self.reader)?;
-                if length == 1 {
-                    self.state = UnsignedDecodingState::get_state(&mut self.reader)?;
-                } else {
-                    self.state = UnsignedDecodingState::Literals { length: length - 1 };
-                }
-                Ok(Some(num))
-            }
-            UnsignedDecodingState::Exhausted => Ok(None),
-        }
-    }
-}
-
-impl<R: Read> Iterator for UnsignedRleReaderV1<R> {
-    type Item = Result<u64>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter_helper().transpose()
-    }
-}
-
-/// Signed version of [`UnsignedDecodingState`].
-enum SignedDecodingState {
-    Initial,
-    Run {
-        base: i64,
-        delta: i64,
-        length: usize,
-    },
-    Literals {
-        length: usize,
-    },
-    Exhausted,
-}
-
-impl SignedDecodingState {
-    fn get_state<R: Read>(reader: &mut R) -> Result<Self> {
-        match try_read_u8(reader)?.map(|byte| byte as i8) {
+    // Returns false if no more bytes
+    fn decode_batch(&mut self) -> Result<bool> {
+        // Decode header byte to determine sub-encoding.
+        // Runs start with a positive byte, and literals with a negative byte.
+        match try_read_u8(&mut self.reader)?.map(|byte| byte as i8) {
+            // Literals
             Some(byte) if byte < 0 => {
-                let length = byte.unsigned_abs() as usize;
-                Ok(Self::Literals { length })
+                let length = byte.unsigned_abs();
+                for _ in 0..length {
+                    let lit = read_varint_zigzagged(&mut self.reader)?;
+                    self.decoded_ints.push(lit);
+                }
+                Ok(true)
             }
+            // Run
             Some(byte) => {
                 let byte = byte as u8;
-                let length = byte as usize + 3;
-                let delta = read_u8(reader)? as i8;
-                let delta = delta as i64;
-                let base = read_vslong(reader)?;
-                Ok(Self::Run {
-                    base,
-                    delta,
-                    length,
-                })
-            }
-            None => Ok(Self::Exhausted),
-        }
-    }
-}
-
-/// Signed version of [`UnsignedIntV1RLEDecoder`].
-pub struct SignedRleReaderV1<R: Read> {
-    reader: R,
-    state: SignedDecodingState,
-}
-
-impl<R: Read> SignedRleReaderV1<R> {
-    pub fn new(reader: R) -> Self {
-        Self {
-            reader,
-            state: SignedDecodingState::Initial,
-        }
-    }
-
-    fn iter_helper(&mut self) -> Result<Option<i64>> {
-        match self.state {
-            SignedDecodingState::Initial => {
-                self.state = SignedDecodingState::get_state(&mut self.reader)?;
-                self.iter_helper()
-            }
-            SignedDecodingState::Run {
-                base,
-                delta,
-                length,
-            } => {
-                let num = base;
-                if length == 1 {
-                    self.state = SignedDecodingState::get_state(&mut self.reader)?;
+                let length = byte + 2; // Technically +3, but we subtract 1 for the base
+                let delta = read_u8(&mut self.reader)? as i8;
+                let mut base = read_varint_zigzagged(&mut self.reader)?;
+                self.decoded_ints.push(base);
+                if delta < 0 {
+                    let delta = delta.unsigned_abs();
+                    let delta = N::from_u8(delta);
+                    for _ in 0..length {
+                        base = base.checked_sub(&delta).context(OutOfSpecSnafu {
+                            msg: "over/underflow when decoding patched base integer",
+                        })?;
+                        self.decoded_ints.push(base);
+                    }
                 } else {
-                    self.state = SignedDecodingState::Run {
-                        base: base.saturating_add(delta),
-                        delta,
-                        length: length - 1,
-                    };
+                    let delta = delta as u8;
+                    let delta = N::from_u8(delta);
+                    for _ in 0..length {
+                        base = base.checked_add(&delta).context(OutOfSpecSnafu {
+                            msg: "over/underflow when decoding patched base integer",
+                        })?;
+                        self.decoded_ints.push(base);
+                    }
                 }
-                Ok(Some(num))
+                Ok(true)
             }
-            SignedDecodingState::Literals { length } => {
-                let num = read_vslong(&mut self.reader)?;
-                if length == 1 {
-                    self.state = SignedDecodingState::get_state(&mut self.reader)?;
-                } else {
-                    self.state = SignedDecodingState::Literals { length: length - 1 };
-                }
-                Ok(Some(num))
-            }
-            SignedDecodingState::Exhausted => Ok(None),
+            None => Ok(false),
         }
     }
 }
 
-impl<R: Read> Iterator for SignedRleReaderV1<R> {
-    type Item = Result<i64>;
+impl<N: NInt, R: Read> Iterator for RleReaderV1<N, R> {
+    type Item = Result<N>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter_helper().transpose()
+        if self.current_head >= self.decoded_ints.len() {
+            self.current_head = 0;
+            self.decoded_ints.clear();
+            match self.decode_batch() {
+                Ok(more) => {
+                    if !more {
+                        return None;
+                    }
+                }
+                Err(err) => {
+                    return Some(Err(err));
+                }
+            }
+        }
+        let result = self.decoded_ints[self.current_head];
+        self.current_head += 1;
+        Some(Ok(result))
     }
 }
 
@@ -231,13 +126,13 @@ mod tests {
     #[test]
     fn test_run() -> Result<()> {
         let input = [0x61, 0x00, 0x07];
-        let decoder = UnsignedRleReaderV1::new(Cursor::new(&input));
+        let decoder = RleReaderV1::<u64, _>::new(Cursor::new(&input));
         let expected = vec![7; 100];
         let actual = decoder.collect::<Result<Vec<_>>>()?;
         assert_eq!(actual, expected);
 
         let input = [0x61, 0xff, 0x64];
-        let decoder = UnsignedRleReaderV1::new(Cursor::new(&input));
+        let decoder = RleReaderV1::<u64, _>::new(Cursor::new(&input));
         let expected = (1..=100).rev().collect::<Vec<_>>();
         let actual = decoder.collect::<Result<Vec<_>>>()?;
         assert_eq!(actual, expected);
@@ -248,7 +143,7 @@ mod tests {
     #[test]
     fn test_literal() -> Result<()> {
         let input = [0xfb, 0x02, 0x03, 0x06, 0x07, 0xb];
-        let decoder = UnsignedRleReaderV1::new(Cursor::new(&input));
+        let decoder = RleReaderV1::<u64, _>::new(Cursor::new(&input));
         let expected = vec![2, 3, 6, 7, 11];
         let actual = decoder.collect::<Result<Vec<_>>>()?;
         assert_eq!(actual, expected);

--- a/src/reader/decode/rle_v2/direct.rs
+++ b/src/reader/decode/rle_v2/direct.rs
@@ -1,28 +1,32 @@
 use std::io::Read;
 
-use crate::error::Result;
-use crate::reader::decode::rle_v2::RleReaderV2;
-use crate::reader::decode::util::{read_ints, read_u8, rle_v2_direct_bit_width, zigzag_decode};
+use crate::error::{OutOfSpecSnafu, Result};
+use crate::reader::decode::util::{
+    extract_run_length_from_header, read_ints, read_u8, rle_v2_decode_bit_width,
+};
 
-impl<R: Read> RleReaderV2<R> {
+use super::{NInt, RleReaderV2};
+
+impl<N: NInt, R: Read> RleReaderV2<N, R> {
     pub fn read_direct_values(&mut self, header: u8) -> Result<()> {
-        let fbo = (header >> 1) & 0x1F;
-        let fb = rle_v2_direct_bit_width(fbo);
+        let encoded_bit_width = (header >> 1) & 0x1F;
+        let bit_width = rle_v2_decode_bit_width(encoded_bit_width);
 
-        // 9 bits for length (L) (1 to 512 values)
-        let second_byte = read_u8(&mut self.reader)?;
-
-        let mut length = ((header as u64 & 0x01) << 8) as usize | second_byte as usize;
-        // runs are one off
-        length += 1;
-
-        // write the unpacked values and zigzag decode to result buffer
-        read_ints(&mut self.literals, length, fb as usize, &mut self.reader)?;
-
-        if self.signed {
-            for lit in self.literals.iter_mut() {
-                *lit = zigzag_decode(*lit as u64);
+        if (N::BYTE_SIZE * 8) < bit_width {
+            return OutOfSpecSnafu {
+                msg: "byte width of direct encoding exceeds byte size of integer being decoded to",
             }
+            .fail();
+        }
+
+        let second_byte = read_u8(&mut self.reader)?;
+        let length = extract_run_length_from_header(header, second_byte);
+
+        // Write the unpacked values and zigzag decode to result buffer
+        read_ints(&mut self.decoded_ints, length, bit_width, &mut self.reader)?;
+
+        for lit in self.decoded_ints.iter_mut() {
+            *lit = lit.zigzag_decode();
         }
 
         Ok(())

--- a/src/reader/decode/rle_v2/patched_base.rs
+++ b/src/reader/decode/rle_v2/patched_base.rs
@@ -1,113 +1,141 @@
-use std::collections::VecDeque;
 use std::io::Read;
 
-use super::RleReaderV2;
-use crate::error::{OutOfSpecSnafu, Result};
+use snafu::{OptionExt, ResultExt};
+
+use super::{NInt, RleReaderV2};
+use crate::error::{IoSnafu, OutOfSpecSnafu, Result};
 use crate::reader::decode::util::{
-    bytes_to_long_be, get_closest_fixed_bits, header_to_rle_v2_direct_bit_width, read_ints,
-    read_u8, rle_v2_direct_bit_width,
+    extract_run_length_from_header, read_ints, read_u8, rle_v2_decode_bit_width,
 };
 
-impl<R: Read> RleReaderV2<R> {
+/// Patches (gap + actual patch bits) width are ceil'd here.
+///
+/// Not mentioned in ORC specification, but happens in their implementation.
+fn get_closest_fixed_bits(width: usize) -> usize {
+    match width {
+        1..=24 => width,
+        25..=26 => 26,
+        27..=28 => 28,
+        29..=30 => 30,
+        31..=32 => 32,
+        33..=40 => 40,
+        41..=48 => 48,
+        49..=56 => 56,
+        57..=64 => 64,
+        _ => unreachable!(),
+    }
+}
+
+impl<N: NInt, R: Read> RleReaderV2<N, R> {
     pub fn read_patched_base(&mut self, header: u8) -> Result<()> {
-        let bit_width = header_to_rle_v2_direct_bit_width(header);
+        let encoded_bit_width = (header >> 1) & 0x1F;
+        let value_bit_width = rle_v2_decode_bit_width(encoded_bit_width);
 
-        let reader = &mut self.reader;
+        let second_byte = read_u8(&mut self.reader)?;
+        let length = extract_run_length_from_header(header, second_byte);
 
-        // 9 bits for length (L) (1 to 512 values)
-        let second_byte = read_u8(reader)?;
+        let third_byte = read_u8(&mut self.reader)?;
+        let fourth_byte = read_u8(&mut self.reader)?;
 
-        let mut length = ((header as u64 & 0x01) << 8) as usize | second_byte as usize;
-        // runs are one off
-        length += 1;
+        // Base width is one off
+        let base_byte_width = ((third_byte >> 5) & 0x07) as usize + 1;
 
-        let third_byte = read_u8(reader)?;
+        let patch_bit_width = rle_v2_decode_bit_width(third_byte & 0x1f);
 
-        let mut base_width = third_byte as u64 >> 5 & 0x07;
-        // base width is one off
-        base_width += 1;
+        // Patch gap width is one off
+        let patch_gap_bit_width = ((fourth_byte >> 5) & 0x07) as usize + 1;
 
-        let patch_width = rle_v2_direct_bit_width(third_byte & 0x1f);
-
-        // reads next
-        let fourth_byte = read_u8(reader)?;
-
-        let mut patch_gap_width = fourth_byte as u64 >> 5 & 0x07;
-        // patch gap width is one off
-        patch_gap_width += 1;
-
-        // extracts the length of the patch list
-        let patch_list_length = fourth_byte & 0x1f;
-
-        let mut base = bytes_to_long_be(reader, base_width as usize)?;
-
-        let mask = 1i64 << ((base_width * 8) - 1);
-        // if MSB of base value is 1 then base is negative value else positive
-        if base & mask != 0 {
-            base &= !mask;
-            base = -base
-        }
-
-        let mut unpacked = VecDeque::with_capacity(length);
-        read_ints(&mut unpacked, length, bit_width as usize, reader)?;
-
-        let width = patch_width as usize + patch_gap_width as usize;
-        if width > 64 {
+        let patch_total_bit_width = patch_bit_width + patch_gap_bit_width;
+        if patch_total_bit_width > 64 {
             return OutOfSpecSnafu {
                 msg: "combined patch width and patch gap width cannot be greater than 64 bits",
             }
             .fail();
         }
+        if (patch_bit_width + value_bit_width) > (N::BYTE_SIZE * 8) {
+            return OutOfSpecSnafu {
+                msg: "combined patch width and value width cannot exceed the size of the integer type being decoded",
+            }
+            .fail();
+        }
 
-        let bit_size = get_closest_fixed_bits(width);
+        let patch_list_length = (fourth_byte & 0x1f) as usize;
 
-        let mut unpacked_patch = VecDeque::with_capacity(patch_list_length as usize);
+        let mut buffer = [0; 8];
+        // Read into back part of buffer since is big endian.
+        // So if smaller than 8 bytes, most significant bytes will be 0.
+        self.reader
+            .read_exact(&mut buffer[8 - base_byte_width..])
+            .context(IoSnafu)?;
+        let base =
+            N::from_be_bytes(&buffer[8 - N::BYTE_SIZE..]).decode_signed_from_msb(base_byte_width);
+
+        // Get data values
         read_ints(
-            &mut unpacked_patch,
-            patch_list_length as usize,
-            bit_size,
-            reader,
+            &mut self.decoded_ints,
+            length,
+            value_bit_width,
+            &mut self.reader,
         )?;
 
+        // Get patches that will be applied to base values.
+        // At most they might be u64 in width (because of check above).
+        let ceil_patch_total_bit_width = get_closest_fixed_bits(patch_total_bit_width);
+        let mut patches: Vec<u64> = Vec::with_capacity(patch_list_length);
+        read_ints(
+            &mut patches,
+            patch_list_length,
+            ceil_patch_total_bit_width,
+            &mut self.reader,
+        )?;
+
+        // TODO: document and explain below logic
         let mut patch_index = 0;
-        let patch_mask = (1 << patch_width) - 1;
-        let mut current_gap = ((unpacked_patch[patch_index] as u64) >> patch_width) as i64;
-        let mut current_patch = unpacked_patch[patch_index] & patch_mask;
-        let mut actual_gap = 0i64;
+        let patch_mask = (1 << patch_bit_width) - 1;
+        let mut current_gap = patches[patch_index] >> patch_bit_width;
+        let mut current_patch = patches[patch_index] & patch_mask;
+        let mut actual_gap = 0;
 
         while current_gap == 255 && current_patch == 0 {
             actual_gap += 255;
             patch_index += 1;
-            current_gap = ((unpacked_patch[patch_index] as u64) >> patch_width) as i64;
-            current_patch = unpacked_patch[patch_index] & patch_mask;
+            current_gap = patches[patch_index] >> patch_bit_width;
+            current_patch = patches[patch_index] & patch_mask;
         }
         actual_gap += current_gap;
 
-        for (i, item) in unpacked.iter().enumerate() {
-            if i == actual_gap as usize {
-                let patched_value = item | (current_patch << bit_width);
+        for (idx, value) in self.decoded_ints.iter_mut().enumerate() {
+            if idx == actual_gap as usize {
+                let patch_bits = current_patch << value_bit_width;
+                // Safe conversion without loss as we check the bit width prior
+                let patch_bits = N::from_u64(patch_bits);
+                let patched_value = *value | patch_bits;
 
-                self.literals.push_back(base + patched_value);
+                *value = patched_value.checked_add(&base).context(OutOfSpecSnafu {
+                    msg: "over/underflow when decoding patched base integer",
+                })?;
 
                 patch_index += 1;
 
-                if patch_index < unpacked_patch.len() {
-                    current_gap = ((unpacked_patch[patch_index] as u64) >> patch_width) as i64;
-                    current_patch = unpacked_patch[patch_index] & patch_mask;
+                if patch_index < patches.len() {
+                    current_gap = patches[patch_index] >> patch_bit_width;
+                    current_patch = patches[patch_index] & patch_mask;
                     actual_gap = 0;
 
                     while current_gap == 255 && current_patch == 0 {
                         actual_gap += 255;
                         patch_index += 1;
-                        current_gap = ((unpacked_patch[patch_index] as u64) >> patch_width) as i64;
-                        current_patch = unpacked_patch[patch_index] & patch_mask;
+                        current_gap = patches[patch_index] >> patch_bit_width;
+                        current_patch = patches[patch_index] & patch_mask;
                     }
 
                     actual_gap += current_gap;
-                    actual_gap += i as i64;
+                    actual_gap += idx as u64;
                 }
             } else {
-                self.literals.push_back(base + item);
+                *value = value.checked_add(&base).context(OutOfSpecSnafu {
+                    msg: "over/underflow when decoding patched base integer",
+                })?;
             }
         }
 

--- a/src/reader/decode/rle_v2/short_repeat.rs
+++ b/src/reader/decode/rle_v2/short_repeat.rs
@@ -1,13 +1,15 @@
 use std::io::Read;
 
-use crate::error::Result;
-use crate::reader::decode::rle_v2::RleReaderV2;
-use crate::reader::decode::util::{bytes_to_long_be, zigzag_decode};
+use snafu::ResultExt;
 
-/// Minimum number of repeated values required to use run length encoding.
+use crate::error::{IoSnafu, OutOfSpecSnafu, Result};
+
+use super::{NInt, RleReaderV2};
+
+/// Minimum number of repeated values required to use this sub-encoding
 const MIN_REPEAT_SIZE: usize = 3;
 
-impl<R: Read> RleReaderV2<R> {
+impl<N: NInt, R: Read> RleReaderV2<N, R> {
     pub fn read_short_repeat_values(&mut self, header: u8) -> Result<()> {
         // Header byte:
         //
@@ -18,25 +20,29 @@ impl<R: Read> RleReaderV2<R> {
         // www = Value width bits
         // ccc = Repeat count bits
 
-        let value_byte_width = (header >> 3) & 0x07; // Encoded as 0 to 7
-        let value_byte_width = value_byte_width as usize + 1; // Decode to 1 to 8 bytes
+        let byte_width = (header >> 3) & 0x07; // Encoded as 0 to 7
+        let byte_width = byte_width as usize + 1; // Decode to 1 to 8 bytes
 
-        let run_length = (header & 0x07) as usize;
-        let run_length = run_length + MIN_REPEAT_SIZE;
-
-        // Value that is being repeated is encoded as N bytes in big endian format
-        // Where N = value_byte_width
-        let val = bytes_to_long_be(&mut self.reader, value_byte_width)?;
-
-        let val = if self.signed {
-            zigzag_decode(val as u64)
-        } else {
-            val
-        };
-
-        for _ in 0..run_length {
-            self.literals.push_back(val);
+        if N::BYTE_SIZE < byte_width {
+            return OutOfSpecSnafu {
+                msg: "byte width of short repeat encoding exceeds byte size of integer being decoded to",
+            }
+            .fail();
         }
+
+        let run_length = (header & 0x07) as usize + MIN_REPEAT_SIZE;
+
+        // Value that is being repeated is encoded as value_byte_width bytes in big endian format
+        let mut buffer = [0; 8];
+        // Read into back part of buffer since is big endian.
+        // So if smaller than 8 bytes, most significant bytes will be 0.
+        self.reader
+            .read_exact(&mut buffer[8 - byte_width..])
+            .context(IoSnafu)?;
+        let val = N::from_be_bytes(&buffer[8 - N::BYTE_SIZE..]).zigzag_decode();
+
+        self.decoded_ints
+            .extend(std::iter::repeat(val).take(run_length));
 
         Ok(())
     }

--- a/src/reader/decompress.rs
+++ b/src/reader/decompress.rs
@@ -7,7 +7,7 @@ use bytes::{Bytes, BytesMut};
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use snafu::ResultExt;
 
-use crate::error::{self, Error};
+use crate::error::{self, OrcError};
 use crate::proto::{self, CompressionKind};
 
 // Spec states default is 256K
@@ -90,7 +90,7 @@ fn decompress_block(
     compression: Compression,
     compressed_bytes: &[u8],
     scratch: &mut Vec<u8>,
-) -> Result<(), Error> {
+) -> Result<(), OrcError> {
     match compression.compression_type {
         CompressionType::Zlib => {
             let mut gz = flate2::read::DeflateDecoder::new(compressed_bytes);
@@ -166,7 +166,7 @@ impl DecompressorIter {
 impl FallibleStreamingIterator for DecompressorIter {
     type Item = [u8];
 
-    type Error = Error;
+    type Error = OrcError;
 
     #[inline]
     fn advance(&mut self) -> Result<(), Self::Error> {

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -81,7 +81,7 @@ pub enum TypeStatistics {
 }
 
 impl TryFrom<&proto::ColumnStatistics> for ColumnStatistics {
-    type Error = error::Error;
+    type Error = error::OrcError;
 
     fn try_from(value: &proto::ColumnStatistics) -> Result<Self, Self::Error> {
         let type_statistics = if let Some(stats) = &value.int_statistics {

--- a/src/stripe.rs
+++ b/src/stripe.rs
@@ -50,7 +50,7 @@ impl StripeMetadata {
 }
 
 impl TryFrom<(&proto::StripeInformation, &proto::StripeStatistics)> for StripeMetadata {
-    type Error = error::Error;
+    type Error = error::OrcError;
 
     fn try_from(
         value: (&proto::StripeInformation, &proto::StripeStatistics),


### PR DESCRIPTION
Closes #56

Introduce generics to the integer decoding behaviour

Will now have RLE decoders (v1 and v2) for each supported Orc integer type, instead of a generic i64/u64 decoder