### PR TITLE
Add support for dictionary stripes

### DIFF
--- a/src/arrow_reader/decoder/map.rs
+++ b/src/arrow_reader/decoder/map.rs
@@ -36,13 +36,9 @@ impl MapArrayDecoder {
         let reader = stripe.stream_map.get(column, Kind::Length)?;
         let lengths = get_rle_reader(column, reader)?;
 
-        let keys_field = Field::new("keys", keys_column.data_type().to_arrow_data_type(), false);
+        let keys_field = Field::new("keys", keys_column.arrow_data_type(), false);
         let keys_field = Arc::new(keys_field);
-        let values_field = Field::new(
-            "values",
-            values_column.data_type().to_arrow_data_type(),
-            true,
-        );
+        let values_field = Field::new("values", values_column.arrow_data_type(), true);
         let values_field = Arc::new(values_field);
 
         let fields = Fields::from(vec![keys_field, values_field]);

--- a/src/arrow_reader/decoder/string.rs
+++ b/src/arrow_reader/decoder/string.rs
@@ -143,6 +143,7 @@ impl<T: ByteArrayType> ArrayBatchDecoder for GenericByteArrayDecoder<T> {
         batch_size: usize,
         parent_present: Option<&[bool]>,
     ) -> Result<ArrayRef> {
+        println!("GenericByteArrayDecoder::next_batch");
         let array = self.next_byte_batch(batch_size, parent_present)?;
         let array = Arc::new(array) as ArrayRef;
         Ok(array)
@@ -169,6 +170,7 @@ impl ArrayBatchDecoder for DictionaryStringArrayDecoder {
         batch_size: usize,
         parent_present: Option<&[bool]>,
     ) -> Result<ArrayRef> {
+        println!("DictionaryStringArrayDecoder::next_batch");
         let keys = self
             .indexes
             .next_primitive_batch(batch_size, parent_present)?;

--- a/src/arrow_reader/decoder/struct_decoder.rs
+++ b/src/arrow_reader/decoder/struct_decoder.rs
@@ -36,7 +36,12 @@ impl StructArrayDecoder {
         let fields = column
             .children()
             .into_iter()
-            .map(Field::from)
+            .map(|col| {
+                println!("col {:#?}", col);
+                let field = Field::from(col);
+                println!("field {:?}", field);
+                field
+            })
             .map(Arc::new)
             .collect::<Vec<_>>();
         let fields = Fields::from(fields);
@@ -64,6 +69,10 @@ impl ArrayBatchDecoder for StructArrayDecoder {
             .collect::<Result<Vec<_>>>()?;
 
         let null_buffer = present.map(NullBuffer::from);
+        println!(
+            "next batch fields = {:?}, child_arrays = {:?}, nulls = {:?}",
+            self.fields, child_arrays, null_buffer
+        );
         let array = StructArray::try_new(self.fields.clone(), child_arrays, null_buffer)
             .context(ArrowSnafu)?;
         let array = Arc::new(array);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -85,7 +85,7 @@ fn metaData() {
     test_expected_file("TestOrcFile.metaData");
 }
 #[test]
-#[ignore] // TODO: Why?
+#[ignore] // TODO: {} instead of [{}] and decimal representation differs
 fn test1() {
     test_expected_file("TestOrcFile.test1");
 }


### PR DESCRIPTION
In Arrow, dictionary columns are a separate data type, while in ORC they are a per-stripe encoding. This means we cannot get an Arrow schema for a whole ORC file, the Arrow schema is only valid per-stripe

Unfortunately, this breaks a feature of this crate (which I assume is important for `datafusion`), and I don't see a way out. Thoughts?

(Note: `test1.orc` has a binary column, so you should apply #67 first if you want to see the change.)