### PR TITLE
chore: bump `arrow` version to 51

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ include = ["src/**/*.rs", "Cargo.toml"]
 rust-version = "1.70"
 
 [dependencies]
-arrow = { version = "50", features = ["prettyprint"] }
+arrow = { version = "51", features = ["prettyprint"] }
 bytes = "1.4"
 chrono = { version = "0.4.37", default-features = false, features = ["std"] }
 chrono-tz = "0.8.6"
@@ -38,7 +38,7 @@ tokio = { version = "1.28", optional = true, features = [
 zstd = "0.12"
 
 [dev-dependencies]
-arrow-json = "50.0.0"
+arrow-json = "51.0.0"
 async-trait = "0.1.77"
 criterion = { version = "0.5", default-features = false, features = ["async_tokio"] }
 datafusion = "36.0.0"


### PR DESCRIPTION
AS TITLE