### PR TITLE
Introduce PrimitiveValueDecoder to enable batch decoding of values

### DIFF
--- a/src/array_decoder/list.rs
+++ b/src/array_decoder/list.rs
@@ -24,7 +24,7 @@ use snafu::ResultExt;
 
 use crate::array_decoder::{derive_present_vec, populate_lengths_with_nulls};
 use crate::column::{get_present_vec, Column};
-use crate::encoding::get_unsigned_rle_reader;
+use crate::encoding::{get_unsigned_rle_reader, PrimitiveValueDecoder};
 use crate::proto::stream::Kind;
 
 use crate::error::{ArrowSnafu, Result};
@@ -35,7 +35,7 @@ use super::{array_decoder_factory, ArrayBatchDecoder};
 pub struct ListArrayDecoder {
     inner: Box<dyn ArrayBatchDecoder>,
     present: Option<Box<dyn Iterator<Item = bool> + Send>>,
-    lengths: Box<dyn Iterator<Item = Result<i64>> + Send>,
+    lengths: Box<dyn PrimitiveValueDecoder<i64> + Send>,
     field: FieldRef,
 }
 

--- a/src/array_decoder/map.rs
+++ b/src/array_decoder/map.rs
@@ -24,7 +24,7 @@ use snafu::ResultExt;
 
 use crate::array_decoder::{derive_present_vec, populate_lengths_with_nulls};
 use crate::column::{get_present_vec, Column};
-use crate::encoding::get_unsigned_rle_reader;
+use crate::encoding::{get_unsigned_rle_reader, PrimitiveValueDecoder};
 use crate::error::{ArrowSnafu, Result};
 use crate::proto::stream::Kind;
 use crate::stripe::Stripe;
@@ -35,7 +35,7 @@ pub struct MapArrayDecoder {
     keys: Box<dyn ArrayBatchDecoder>,
     values: Box<dyn ArrayBatchDecoder>,
     present: Option<Box<dyn Iterator<Item = bool> + Send>>,
-    lengths: Box<dyn Iterator<Item = Result<i64>> + Send>,
+    lengths: Box<dyn PrimitiveValueDecoder<i64> + Send>,
     fields: Fields,
 }
 

--- a/src/array_decoder/string.rs
+++ b/src/array_decoder/string.rs
@@ -28,7 +28,7 @@ use snafu::ResultExt;
 use crate::array_decoder::{create_null_buffer, derive_present_vec, populate_lengths_with_nulls};
 use crate::column::{get_present_vec, Column};
 use crate::compression::Decompressor;
-use crate::encoding::get_unsigned_rle_reader;
+use crate::encoding::{get_unsigned_rle_reader, PrimitiveValueDecoder};
 use crate::error::{ArrowSnafu, IoSnafu, Result};
 use crate::proto::column_encoding::Kind as ColumnEncodingKind;
 use crate::proto::stream::Kind;
@@ -90,7 +90,7 @@ pub type BinaryArrayDecoder = GenericByteArrayDecoder<GenericBinaryType<i32>>;
 
 pub struct GenericByteArrayDecoder<T: ByteArrayType> {
     bytes: Box<Decompressor>,
-    lengths: Box<dyn Iterator<Item = Result<i64>> + Send>,
+    lengths: Box<dyn PrimitiveValueDecoder<i64> + Send>,
     present: Option<Box<dyn Iterator<Item = bool> + Send>>,
     phantom: PhantomData<T>,
 }
@@ -98,7 +98,7 @@ pub struct GenericByteArrayDecoder<T: ByteArrayType> {
 impl<T: ByteArrayType> GenericByteArrayDecoder<T> {
     fn new(
         bytes: Box<Decompressor>,
-        lengths: Box<dyn Iterator<Item = Result<i64>> + Send>,
+        lengths: Box<dyn PrimitiveValueDecoder<i64> + Send>,
         present: Option<Box<dyn Iterator<Item = bool> + Send>>,
     ) -> Self {
         Self {

--- a/src/array_decoder/timestamp.rs
+++ b/src/array_decoder/timestamp.rs
@@ -23,6 +23,7 @@ use crate::{
     encoding::{
         get_rle_reader, get_unsigned_rle_reader,
         timestamp::{TimestampIterator, TimestampNanosecondAsDecimalIterator},
+        PrimitiveValueDecoder,
     },
     error::{MismatchedSchemaSnafu, Result},
     proto::stream::Kind,
@@ -108,7 +109,7 @@ fn decimal128_decoder(
 
     let iter = TimestampNanosecondAsDecimalIterator::new(seconds_since_unix_epoch, data, secondary);
 
-    let iter: Box<dyn Iterator<Item = _> + Send> = match writer_tz {
+    let iter: Box<dyn PrimitiveValueDecoder<i128> + Send> = match writer_tz {
         Some(UTC) | None => Box::new(iter),
         Some(writer_tz) => Box::new(TimestampNanosecondAsDecimalWithTzIterator(iter, writer_tz)),
     };
@@ -314,3 +315,5 @@ impl Iterator for TimestampNanosecondAsDecimalWithTzIterator {
         Some(self.next_inner(ts))
     }
 }
+
+impl PrimitiveValueDecoder<i128> for TimestampNanosecondAsDecimalWithTzIterator {}

--- a/src/encoding/byte.rs
+++ b/src/encoding/byte.rs
@@ -20,7 +20,7 @@ use bytes::{BufMut, BytesMut};
 use crate::{error::Result, memory::EstimateMemory};
 use std::io::Read;
 
-use super::{util::read_u8, PrimitiveValueEncoder};
+use super::{util::read_u8, PrimitiveValueDecoder, PrimitiveValueEncoder};
 
 const MAX_LITERAL_LENGTH: usize = 128;
 const MIN_REPEAT_LENGTH: usize = 3;
@@ -244,6 +244,8 @@ impl<R: Read> Iterator for ByteRleReader<R> {
         Some(Ok(result as i8))
     }
 }
+
+impl<R: Read> PrimitiveValueDecoder<i8> for ByteRleReader<R> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/encoding/float.rs
+++ b/src/encoding/float.rs
@@ -26,7 +26,7 @@ use crate::{
     memory::EstimateMemory,
 };
 
-use super::PrimitiveValueEncoder;
+use super::{PrimitiveValueDecoder, PrimitiveValueEncoder};
 
 /// Generically represent f32 and f64.
 // TODO: figure out how to use num::traits::FromBytes instead of rolling our own?
@@ -71,6 +71,8 @@ impl<T: Float, R: std::io::Read> FloatIter<T, R> {
         }
     }
 }
+
+impl<T: Float, R: std::io::Read> PrimitiveValueDecoder<T> for FloatIter<T, R> {}
 
 impl<T: Float, R: std::io::Read> Iterator for FloatIter<T, R> {
     type Item = Result<T>;

--- a/src/encoding/rle_v1.rs
+++ b/src/encoding/rle_v1.rs
@@ -25,7 +25,7 @@ use crate::error::{OutOfSpecSnafu, Result};
 
 use super::{
     util::{read_u8, read_varint_zigzagged, try_read_u8},
-    EncodingSign, NInt,
+    EncodingSign, NInt, PrimitiveValueDecoder,
 };
 
 const MAX_RUN_LENGTH: usize = 130;
@@ -118,6 +118,8 @@ impl<N: NInt, R: Read, S: EncodingSign> Iterator for RleReaderV1<N, R, S> {
         Some(Ok(result))
     }
 }
+
+impl<N: NInt, R: Read, S: EncodingSign> PrimitiveValueDecoder<N> for RleReaderV1<N, R, S> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Though the benchmarks are kinda simple, they identified (via flamegraph) that there was a significant amount of time being spent on next() calls in RleReaderV2. So introduce a new PrimitiveValueDecoder to enable batch decoding support, currently only properly implemented for integer arrays with no null buffer. Even so, benchmarks show significant improvement:

```
datafusion-orc$ cargo bench
   Compiling orc-rust v0.3.1 (/home/jeffrey/Code/datafusion-orc)
    Finished `bench` profile [optimized + debuginfo] target(s) in 11.65s
     Running unittests src/lib.rs (/media/jeffrey/1tb_860evo_ssd/.cargo_target_cache/release/deps/orc_rust-53e462447a03afd6)

...

     Running benches/arrow_reader.rs (/media/jeffrey/1tb_860evo_ssd/.cargo_target_cache/release/deps/arrow_reader-419fc98a1d304edb)
Benchmarking sync reader: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, or reduce sample count to 60.
sync reader             time:   [79.523 ms 79.618 ms 79.721 ms]
                        change: [-42.234% -42.072% -41.919%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

Benchmarking async reader: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.0s, or reduce sample count to 60.
async reader            time:   [80.297 ms 81.019 ms 81.933 ms]
                        change: [-42.186% -41.637% -40.978%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
```

Next steps would be to use this in more places (over current Iterator::next() approach), with accompanying benchmarks to prove its a performance improvement.