### PR TITLE
Support filter out strip by provided range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ private/
 
 /perf.*
 /flamegraph.svg
+
+# IDEA
+.idea/

--- a/src/arrow_reader.rs
+++ b/src/arrow_reader.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::HashMap;
+use std::ops::Range;
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
@@ -28,7 +29,7 @@ use crate::projection::ProjectionMask;
 use crate::reader::metadata::{read_metadata, FileMetadata};
 use crate::reader::ChunkReader;
 use crate::schema::RootDataType;
-use crate::stripe::Stripe;
+use crate::stripe::{Stripe, StripeMetadata};
 
 const DEFAULT_BATCH_SIZE: usize = 8192;
 
@@ -38,6 +39,7 @@ pub struct ArrowReaderBuilder<R> {
     pub(crate) batch_size: usize,
     pub(crate) projection: ProjectionMask,
     pub(crate) schema_ref: Option<SchemaRef>,
+    pub(crate) file_byte_range: Option<Range<usize>>,
 }
 
 impl<R> ArrowReaderBuilder<R> {
@@ -48,6 +50,7 @@ impl<R> ArrowReaderBuilder<R> {
             batch_size: DEFAULT_BATCH_SIZE,
             projection: ProjectionMask::all(),
             schema_ref: None,
+            file_byte_range: None,
         }
     }
 
@@ -67,6 +70,12 @@ impl<R> ArrowReaderBuilder<R> {
 
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema_ref = Some(schema);
+        self
+    }
+
+    /// Specifies a range of file bytes that will read the strips offset within this range
+    pub fn with_file_byte_range(mut self, range: Range<usize>) -> Self {
+        self.file_byte_range = Some(range);
         self
     }
 
@@ -108,6 +117,7 @@ impl<R: ChunkReader> ArrowReaderBuilder<R> {
             file_metadata: self.file_metadata,
             projected_data_type,
             stripe_index: 0,
+            file_byte_range: self.file_byte_range,
         };
         ArrowReader {
             cursor,
@@ -176,14 +186,32 @@ pub(crate) struct Cursor<R> {
     pub file_metadata: Arc<FileMetadata>,
     pub projected_data_type: RootDataType,
     pub stripe_index: usize,
+    pub file_byte_range: Option<Range<usize>>,
+}
+
+impl<R: ChunkReader> Cursor<R> {
+    fn get_stripe_metadatas(&self) -> Vec<StripeMetadata> {
+        if let Some(range) = self.file_byte_range.clone() {
+            self.file_metadata
+                .stripe_metadatas()
+                .iter()
+                .filter(|info| {
+                    let offset = info.offset() as usize;
+                    range.contains(&offset)
+                })
+                .map(|info| info.to_owned())
+                .collect::<Vec<_>>()
+        } else {
+            self.file_metadata.stripe_metadatas().to_vec()
+        }
+    }
 }
 
 impl<R: ChunkReader> Iterator for Cursor<R> {
     type Item = Result<Stripe>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.file_metadata
-            .stripe_metadatas()
+        self.get_stripe_metadatas()
             .get(self.stripe_index)
             .map(|info| {
                 let stripe = Stripe::new(

--- a/src/async_arrow_reader.rs
+++ b/src/async_arrow_reader.rs
@@ -104,6 +104,13 @@ impl<R: AsyncChunkReader + 'static> StripeFactory<R> {
             .cloned();
 
         if let Some(info) = info {
+            if let Some(range) = self.inner.file_byte_range.clone() {
+                let offset = info.offset() as usize;
+                if !range.contains(&offset) {
+                    self.inner.stripe_index += 1;
+                    return Ok((self, None));
+                }
+            }
             match self.read_next_stripe_inner(&info).await {
                 Ok(stripe) => Ok((self, Some(stripe))),
                 Err(err) => Err(err),
@@ -214,6 +221,7 @@ impl<R: AsyncChunkReader + 'static> ArrowReaderBuilder<R> {
             file_metadata: self.file_metadata,
             projected_data_type,
             stripe_index: 0,
+            file_byte_range: self.file_byte_range,
         };
         ArrowStreamReader::new(cursor, self.batch_size, schema_ref)
     }


### PR DESCRIPTION
Since spark orc file format will slice a file into multiple orc splits, support filter out strip by provided range will avoid reading whole orc data file.