### PR TITLE
Release 0.4.1 to fix features on docs.rs page

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orc-rust"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 homepage = "https://github.com/datafusion-contrib/datafusion-orc"
 repository = "https://github.com/datafusion-contrib/datafusion-orc"
@@ -10,6 +10,9 @@ description = "Implementation of Apache ORC file format using Apache Arrow in-me
 keywords = ["arrow", "orc", "arrow-rs", "datafusion"]
 include = ["src/**/*.rs", "Cargo.toml"]
 rust-version = "1.73"
+
+[package.metadata.docs.rs]
+all-features = true
 
 [dependencies]
 arrow = { version = "52", features = ["prettyprint", "chrono-tz"] }


### PR DESCRIPTION
See #129

Do a minor release so `datafusion` feature will show on docs.rs especially because we reference it in the docs:

https://github.com/datafusion-contrib/datafusion-orc/blob/be8a685c25a028caa2aa8356dcefddee783349a9/src/lib.rs#L49-L50