### PR TITLE
[RFC] Use libcramjam for compression codecs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,12 @@ bytes = "1.4"
 chrono = { version = "0.4.37", default-features = false, features = ["std"] }
 chrono-tz = "0.9"
 fallible-streaming-iterator = { version = "0.1" }
-flate2 = "1"
-lz4_flex = "0.11"
 lzokay-native = "0.1"
 num = "0.4.1"
 prost = { version = "0.12" }
 snafu = "0.8"
-snap = "1.1"
-zstd = "0.12"
+
+libcramjam = { version = "*", default-features = false, features = ["snappy", "zstd", "lz4", "gzip", "zlib", "deflate"] }
 
 # async support
 async-trait = { version = "0.1.77", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,7 +142,7 @@ pub enum OrcError {
     BuildSnappyDecoder {
         #[snafu(implicit)]
         location: Location,
-        source: snap::Error,
+        source: libcramjam::snappy::snap::Error,
     },
 
     #[snafu(display("Failed to build lzo decoder: {}", source))]
@@ -156,7 +156,7 @@ pub enum OrcError {
     BuildLz4Decoder {
         #[snafu(implicit)]
         location: Location,
-        source: lz4_flex::block::DecompressError,
+        source: io::Error,
     },
 
     #[snafu(display("Arrow error: {}", source))]


### PR DESCRIPTION
See if there was any interest in using [libcramjam](https://github.com/cramjam/libcramjam). 

There's probably further use/simplification available here, and could anyway help libcramjam's implementation. It's presently used in python's [cramjam](https://github.com/milesgranger/cramjam) package that has served quite well.

datafusion-orc could make use of other codecs as well with low overhead that are already part of libcramjam (brotli, bzip2, xz, etc and the [ISA-L](https://github.com/intel/isa-l) backed zlib/deflate/gzip algorithms which are quite a bit faster than flate2 w/ zlib-ng [1] (at the expense of more C code and reduced compression level options 0, 1, 3)

I was blissfully unaware there existed a MIT friendly LZO implementation so might add that to libcramjam as well going forward.

[1] https://github.com/milesgranger/isal-rs/tree/main?tab=readme-ov-file#benchmarks