### PR TITLE
chore: use reexported object_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ bytes = "1.4"
 datafusion = "54.0.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3" }
-object_store = { version = "0.13" }
 orc-rust = { version = "0.8", features = ["async"] }
 tokio = { version = "1.28", features = [
     "io-util",

--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -26,6 +26,8 @@ use datafusion::datasource::file_format::FileFormat;
 use datafusion::datasource::physical_plan::{FileScanConfig, FileSource};
 use datafusion::datasource::table_schema::TableSchema;
 use datafusion::error::{DataFusionError, Result};
+use datafusion::object_store::path::Path;
+use datafusion::object_store::{ObjectMeta, ObjectStore};
 use datafusion::physical_plan::ExecutionPlan;
 use futures::TryStreamExt;
 use orc_rust::reader::metadata::read_metadata_async;
@@ -35,8 +37,6 @@ use async_trait::async_trait;
 use datafusion::catalog::Session;
 use datafusion::datasource::source::DataSourceExec;
 use futures_util::StreamExt;
-use object_store::path::Path;
-use object_store::{ObjectMeta, ObjectStore};
 
 use super::object_store_reader::ObjectStoreReader;
 

--- a/src/file_source.rs
+++ b/src/file_source.rs
@@ -19,9 +19,9 @@ use crate::physical_exec::OrcOpener;
 use datafusion::common::DataFusionError;
 use datafusion::datasource::physical_plan::{FileOpener, FileScanConfig, FileSource};
 use datafusion::datasource::table_schema::TableSchema;
+use datafusion::object_store::ObjectStore;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::projection::ProjectionExprs;
-use object_store::ObjectStore;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]

--- a/src/object_store_reader.rs
+++ b/src/object_store_reader.rs
@@ -18,11 +18,10 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use datafusion::object_store::{GetOptions, ObjectMeta, ObjectStore, ObjectStoreExt};
 use futures::future::BoxFuture;
 use futures::{FutureExt, TryFutureExt};
 use orc_rust::reader::AsyncChunkReader;
-
-use object_store::{GetOptions, ObjectMeta, ObjectStore, ObjectStoreExt};
 
 /// Implements [`AsyncChunkReader`] to allow reading ORC files via `object_store` API.
 pub struct ObjectStoreReader {

--- a/src/physical_exec.rs
+++ b/src/physical_exec.rs
@@ -22,12 +22,11 @@ use datafusion::arrow::error::ArrowError;
 use datafusion::datasource::listing::PartitionedFile;
 use datafusion::datasource::physical_plan::{FileOpenFuture, FileOpener};
 use datafusion::error::Result;
+use datafusion::object_store::ObjectStore;
 use datafusion::physical_plan::projection::ProjectionExprs;
+use futures_util::{StreamExt, TryStreamExt};
 use orc_rust::projection::ProjectionMask;
 use orc_rust::ArrowReaderBuilder;
-
-use futures_util::{StreamExt, TryStreamExt};
-use object_store::ObjectStore;
 
 use super::object_store_reader::ObjectStoreReader;
 


### PR DESCRIPTION
Use the `object_store` reexported from datafusion to avoid potential conflict.